### PR TITLE
Center header elements for large header text 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -261,4 +261,10 @@ main {
   .main_button_item {
     width: 92vw;
   }
+  
+  .header_h_item {
+    width: 92vw;
+    text-align: center;
+  }
+  
 }

--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@ https://github.com/ardacarofficial/links-website is open source project.
         <img src="img/logo.png" alt="Logo" />
       </div>
       <div class="header_text flex_column_center">
-        <h1>Your Title</h1>
-        <h2>Your Description</h2>
+        <h1 class="header_h_item">Your Title</h1>
+        <h2 class="header_h_item">Your Description</h2>
       </div>
     <!-- Logo, Title and Description Codes End -->  
 


### PR DESCRIPTION
Noticed that when using large amount of header text, e.g. long name or description, if the text clips over the edge then the header defaults to being left aligned and hard against the left edge of the window. 

This should center-align the text and also set the appropriate width for H1/H2 header element equal to the rest of the page.


<img width="592" alt="image" src="https://github.com/ardacarofficial/links-website/assets/19201714/3c374b07-b9ec-402d-b2e4-0247b5778619">


<img width="701" alt="image" src="https://github.com/ardacarofficial/links-website/assets/19201714/fb3dede1-f1e4-4f3b-b4fa-e52b82b20a6a">
